### PR TITLE
Fix dropdown menu z-index issue on tasks tab

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -838,9 +838,6 @@ th.sortable:hover .sort-indicator {
     font-size: 0.85rem;
 }
 
-.task-card {
-    z-index: 1;
-}
 
 .dropdown-menu {
     position: absolute;


### PR DESCRIPTION
The dropdown menu on the tasks tab was appearing behind the task cards. This was caused by the .task-card having a z-index of 1, which created a new stacking context and limited the z-index of its children.

This commit removes the z-index from the .task-card class in css/styles.css to resolve the issue.