### PR TITLE
Fix: Prevent navigation when clicking project card checkbox

### DIFF
--- a/js/projects.js
+++ b/js/projects.js
@@ -72,7 +72,7 @@ function renderProjectList(containerId) {
         return `
             <div class="project-card" onclick="showProjectDetails(${project.id})" style="cursor: pointer; position: relative; padding-top: 2rem;">
                  <!-- Checkbox for selection -->
-                <div style="position: absolute; top: 0.5rem; left: 0.5rem;" onclick="event.stopPropagation();">
+                <div style="position: absolute; top: 0.5rem; left: 0.5rem;">
                     <input type="checkbox" class="project-checkbox" data-project-id="${project.id}" id="select-project-${project.id}" ${isSelected ? 'checked' : ''}>
                 </div>
                 <div class="project-header">
@@ -126,7 +126,20 @@ function renderProjectList(containerId) {
         // Remove old listener to prevent duplicates
         checkbox.removeEventListener('change', handleProjectCheckboxChange);
         checkbox.addEventListener('change', handleProjectCheckboxChange);
+
+        // --- NEW FIX: Stop click propagation on the checkbox wrapper ---
+        const checkboxWrapper = checkbox.parentElement;
+        if (checkboxWrapper) {
+            // Remove listener first to avoid duplicates if re-rendering
+            checkboxWrapper.removeEventListener('click', stopPropagationOnClick);
+            checkboxWrapper.addEventListener('click', stopPropagationOnClick);
+        }
     });
+
+    // Helper function to be used as the event listener
+    function stopPropagationOnClick(event) {
+        event.stopPropagation();
+    }
 
     const bulkDeleteProjectsBtn = document.getElementById('bulkDeleteProjectsBtn');
     if (bulkDeleteProjectsBtn) {


### PR DESCRIPTION
Clicking the checkbox on a project card was causing the page to navigate to the project details page. This was due to the click event bubbling up to the parent project card element, which has an onclick handler for navigation.

This change adds a javascript event listener to the checkbox container div to prevent the event from bubbling up, allowing the checkbox to be clicked without triggering navigation.