### PR TITLE
Fix(tasks): Prevent dropdown menu from closing immediately

### DIFF
--- a/js/tasks.js
+++ b/js/tasks.js
@@ -852,6 +852,8 @@ document.addEventListener('DOMContentLoaded', function () {
         tasksContainer.addEventListener('click', function (e) {
             const toggleButton = e.target.closest('.dropdown-toggle');
             if (toggleButton && toggleButton.dataset.taskId) {
+                // Stop the event from bubbling up to the document's click listener
+                e.stopPropagation();
                 toggleTaskPageDropdown(parseInt(toggleButton.dataset.taskId, 10));
             }
         });


### PR DESCRIPTION
The three-dotted button on task cards was not displaying the dropdown menu upon being clicked.

This was caused by a conflicting click event listener on the `document` object. The event listener responsible for opening the dropdown on the `tasksContainer` would fire, but the event would then bubble up to the `document`, where another listener would immediately close it.

This is resolved by adding `e.stopPropagation()` to the `tasksContainer`'s click event handler. This prevents the event from reaching the `document` listener when the dropdown toggle button is clicked, allowing the menu to open and remain visible as expected.